### PR TITLE
Removed LDFLAGS which conflicts w/system variable of same name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 CC       = gcc
 CPPFLAGS = $(DFLAGS) $(INCLUDES)
 CFLAGS   = -g -Wall -O2
-LDFLAGS  =
+#LDFLAGS  =
 DFLAGS=		-D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -D_CURSES_LIB=1
 LOBJS=		bam_aux.o bam.o bam_import.o sam.o \
 			sam_header.o


### PR DESCRIPTION
The LDFLAGS= over-writes the system variable of the same name.  On compute clusters using the modules system, this means that dependent libraries whose -L flags are appended or prepended to LDFLAGS via a module load command get over-written when "make" is executed and the final link step fails.
